### PR TITLE
Evaluate the stub only once, and before the var rebinding is done

### DIFF
--- a/src/mock_clj/core.clj
+++ b/src/mock_clj/core.clj
@@ -19,16 +19,18 @@
 
 (defmacro make-mock 
   ([] `(make-mock nil))
-  ([stub] 
-   `(let [~'state (atom [])]
-     (with-meta
-       (fn [& ~'args] 
-         (swap! ~'state conj ~'args)
-         ; If stub is a function, execute it
-         (if (fn? ~stub) 
-           (apply ~stub ~'args)
-           ~stub))
-       {:args ~'state}))))
+  ([stub]
+   (let [stub-symbol-name (gensym)]
+     `(let [~'state (atom [])
+            ~stub-symbol-name ~stub]
+        (with-meta
+          (fn [& ~'args]
+            (swap! ~'state conj ~'args)
+            ; If stub is a function, execute it
+            (if (fn? ~stub-symbol-name)
+              (apply ~stub-symbol-name ~'args)
+              ~stub-symbol-name))
+          {:args ~'state})))))
 
 (defn- gen-redefs [[m stub & spec]]
   (let [sm (try-strip-var m)]

--- a/test/mock_clj/core_test.clj
+++ b/test/mock_clj/core_test.clj
@@ -32,6 +32,13 @@
     (is (= (foo 4) 3))
     (is (= (type 4) "SOME"))))
 
+(deftest with-mock-calling-same-function
+  (with-mock [foo (foo "bar")]
+    (is (= (foo 1 2 3) "foobar")))
+
+  (with-mock [foo (constantly (foo "bar"))]
+    (is (= (foo 1 2 3) "foobar"))))
+
 (deftest calls-test
   (with-mock [foo 5]
     (foo 1 2 3)


### PR DESCRIPTION
In the current implementation, code such as
```
(with-mock [foo (foo "bar")]
    ...)
```
results in a `StackOverflowError`, because `(foo "bar")` on the right is actually evaluated _after_ the var is rebound. This is contrary to the behaviour of `with-redefs`, which evaluates the expressions on the right before rebinding the vars. Also, if `foo` performed side effects, they could potentially be performed more than once.

This PR fixes both of these issues.